### PR TITLE
Enable function without taking[…] after include

### DIFF
--- a/detach.gemspec
+++ b/detach.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new {|s|
 	s.name = 'detach'
-	s.version = '0.1.0'
+	s.version = '0.2.0'
 	s.licenses = ['MIT']
 	s.summary = 'Separate methods by argument types'
 	s.description = 'A mixin which separates method definitions by argument types, effectively allowing C++ or Java style overloading.'

--- a/lib/detach.rb
+++ b/lib/detach.rb
@@ -115,6 +115,11 @@ module Detach
 		# All methods added to a class which are decorated as taking specified types
 		# are aliased in a form known and searched at run-time.
 		def method_added(name)
+            begin
+                @@types     # catch uninitialized @@types here to enable function without taking-prefix
+            rescue
+                return
+            end
 			return unless @@types
 
 			# query the parameter info for the method just added


### PR DESCRIPTION
In 0.1, as soon as the `include Detach` is added to the code the first following functions has to have the taking[…] declaration, otherwise it will throw a `uninitialized class variable @@types in Detach::Types (NameError)`. Especially annoying for stuff like attr_accessor that is normally after the include, but before such a function definition.

This fixes that by ignoring added functions when taking was not already used and thus @@types not initialized.
